### PR TITLE
Possible suggestions

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -80,7 +80,7 @@ describe('Selection TestCase', function () {
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
-            placeCursorInsideElement(editor.elements[0].querySelector('span').firstChild, 1); // end of first span
+            placeCursorInsideElement(editor.elements[0].querySelector('span'), 1); // end of first span
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -80,7 +80,7 @@ describe('Selection TestCase', function () {
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
-            placeCursorInsideElement(editor.elements[1].querySelector('span'), 1); // end of first span
+            placeCursorInsideElement(editor.elements[1].querySelector('span').firstChild, 1); // end of first span
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -142,6 +142,16 @@ describe('Selection TestCase', function () {
             expect(exportedSelection.emptyBlocksIndex).toEqual(2);
         });
 
+        it('should export a position indicating the cursor is after an empty block element', function () {
+            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p>Whatever</p>');
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            placeCursorInsideElement(editor.elements[1].querySelector('h2'), 0);
+            var exportedSelection = editor.exportSelection();
+            expect(exportedSelection.emptyBlocksIndex).toEqual(2);
+        });
+
         it('should import a position with the cursor in an empty paragraph', function () {
             this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>');
             var editor = this.newMediumEditor('.editor', {
@@ -172,6 +182,38 @@ describe('Selection TestCase', function () {
 
             var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
             expect(startParagraph).toBe(editor.elements[1].getElementsByTagName('p')[2], 'paragraph after empty paragraph');
+        });
+
+        it('should import a position with the cursor after an empty block element', function () {
+            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p>Whatever</p>');
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            editor.importSelection({
+                'start': 14,
+                'end': 14,
+                'editableElementIndex': 1,
+                'emptyBlocksIndex': 2
+            });
+
+            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'h2');
+            expect(startParagraph).toBe(editor.elements[1].querySelector('h2'), 'block element after empty block element');
+        });
+
+        it('should import a position with the cursor after an empty block element inside an element with various children', function () {
+            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p><b><i>Whatever</i></b></p>');
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            editor.importSelection({
+                'start': 14,
+                'end': 14,
+                'editableElementIndex': 1,
+                'emptyBlocksIndex': 3
+            });
+
+            var innerElement = window.getSelection().getRangeAt(0).startContainer;
+            expect(Util.isDescendant(editor.elements[1].querySelector('i'), innerElement, true)).toBe(true, 'nested inline elment inside block element after empty block element');
         });
     });
 

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -215,6 +215,24 @@ describe('Selection TestCase', function () {
             var innerElement = window.getSelection().getRangeAt(0).startContainer;
             expect(Util.isDescendant(editor.elements[1].querySelector('i'), innerElement, true)).toBe(true, 'nested inline elment inside block element after empty block element');
         });
+
+        it('should import not import a selection beyond any block elements that have text, even when emptyBlocksIndex indicates it should ', function () {
+            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2>Not Empty</h2><p><b><i>Whatever</i></b></p>');
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            // Import a selection that indicates the text should be at the end of the 'www.google.com' word, but in the 3rd paragraph (at the beginning of 'Whatever')
+            editor.importSelection({
+                'start': 14,
+                'end': 14,
+                'editableElementIndex': 1,
+                'emptyBlocksIndex': 3
+            });
+
+            var innerElement = window.getSelection().getRangeAt(0).startContainer;
+            expect(Util.isDescendant(editor.elements[1].querySelectorAll('p')[1], innerElement, true)).toBe(false, 'moved selection beyond non-empty block element');
+            expect(Util.isDescendant(editor.elements[1].querySelector('h2'), innerElement, true)).toBe(true, 'moved selection to element to incorrect block element');
+        });
     });
 
     describe('Saving Selection', function () {

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -76,99 +76,113 @@ describe('Selection TestCase', function () {
         });
 
         it('should not export a position indicating the cursor is before an empty paragraph', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
-            placeCursorInsideElement(editor.elements[1].querySelector('span').firstChild, 1); // end of first span
+            placeCursorInsideElement(editor.elements[0].querySelector('span').firstChild, 1); // end of first span
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });
 
         it('should not export a position indicating the cursor is after an empty paragraph', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p>' +
-                '<p class="target">Whatever</p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p>' +
+                '<p class="target">Whatever</p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
             // After the 'W' in whatever
-            placeCursorInsideElement(editor.elements[1].querySelector('p.target').firstChild, 1);
+            placeCursorInsideElement(editor.elements[0].querySelector('p.target').firstChild, 1);
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });
 
         it('should not export a position indicating the cursor is after an empty paragraph (in a complicated markup case)',
                 function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p>' +
-                '<p>What<span class="target">ever</span></p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p>' +
+                '<p>What<span class="target">ever</span></p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
             // Before the 'e' in whatever
-            placeCursorInsideElement(editor.elements[1].querySelector('span.target').firstChild, 0);
+            placeCursorInsideElement(editor.elements[0].querySelector('span.target').firstChild, 0);
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });
         it('should not export a position indicating the cursor is after an empty paragraph ' +
                 '(in a complicated markup with selection on the element)', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p>' +
-                '<p>What<span class="target">ever</span></p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p>' +
+                '<p>What<span class="target">ever</span></p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
             // Before the 'e' in whatever
-            placeCursorInsideElement(editor.elements[1].querySelector('span.target'), 0);
+            placeCursorInsideElement(editor.elements[0].querySelector('span.target'), 0);
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });
 
         it('should export a position indicating the cursor is in an empty paragraph', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
-            placeCursorInsideElement(editor.elements[1].getElementsByTagName('p')[1], 0);
+            placeCursorInsideElement(editor.elements[0].getElementsByTagName('p')[1], 0);
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(1);
         });
 
         it('should export a position indicating the cursor is after an empty paragraph', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
-            placeCursorInsideElement(editor.elements[1].getElementsByTagName('p')[2], 0);
+            placeCursorInsideElement(editor.elements[0].getElementsByTagName('p')[2], 0);
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(2);
         });
 
         it('should export a position indicating the cursor is after an empty block element', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p>Whatever</p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p>Whatever</p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
-            placeCursorInsideElement(editor.elements[1].querySelector('h2'), 0);
+            placeCursorInsideElement(editor.elements[0].querySelector('h2'), 0);
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(2);
         });
 
         it('should import a position with the cursor in an empty paragraph', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
             editor.importSelection({
                 'start': 14,
                 'end': 14,
-                'editableElementIndex': 1,
                 'emptyBlocksIndex': 1
             });
 
             var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
-            expect(startParagraph).toBe(editor.elements[1].getElementsByTagName('p')[1], 'empty paragraph');
+            expect(startParagraph).toBe(editor.elements[0].getElementsByTagName('p')[1], 'empty paragraph');
         });
 
         it('should import a position with the cursor after an empty paragraph', function () {
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>';
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            editor.importSelection({
+                'start': 14,
+                'end': 14,
+                'emptyBlocksIndex': 2
+            });
+
+            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
+            expect(startParagraph).toBe(editor.elements[0].getElementsByTagName('p')[2], 'paragraph after empty paragraph');
+        });
+
+        it('should import a position with the cursor after an empty paragraph when there are multipled editable elements', function () {
             this.createElement('div', 'editor', '<p><span>www.google.com</span></p><p><br /></p><p>Whatever</p>');
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
@@ -185,39 +199,37 @@ describe('Selection TestCase', function () {
         });
 
         it('should import a position with the cursor after an empty block element', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p>Whatever</p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p>Whatever</p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
             editor.importSelection({
                 'start': 14,
                 'end': 14,
-                'editableElementIndex': 1,
                 'emptyBlocksIndex': 2
             });
 
             var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'h2');
-            expect(startParagraph).toBe(editor.elements[1].querySelector('h2'), 'block element after empty block element');
+            expect(startParagraph).toBe(editor.elements[0].querySelector('h2'), 'block element after empty block element');
         });
 
         it('should import a position with the cursor after an empty block element inside an element with various children', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p><b><i>Whatever</i></b></p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p><b><i>Whatever</i></b></p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
             editor.importSelection({
                 'start': 14,
                 'end': 14,
-                'editableElementIndex': 1,
                 'emptyBlocksIndex': 3
             });
 
             var innerElement = window.getSelection().getRangeAt(0).startContainer;
-            expect(Util.isDescendant(editor.elements[1].querySelector('i'), innerElement, true)).toBe(true, 'nested inline elment inside block element after empty block element');
+            expect(Util.isDescendant(editor.elements[0].querySelector('i'), innerElement, true)).toBe(true, 'nested inline elment inside block element after empty block element');
         });
 
         it('should import not import a selection beyond any block elements that have text, even when emptyBlocksIndex indicates it should ', function () {
-            this.createElement('div', 'editor', '<p><span>www.google.com</span></p><h1><br /></h1><h2>Not Empty</h2><p><b><i>Whatever</i></b></p>');
+            this.el.innerHTML = '<p><span>www.google.com</span></p><h1><br /></h1><h2>Not Empty</h2><p><b><i>Whatever</i></b></p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']
             });
@@ -225,13 +237,12 @@ describe('Selection TestCase', function () {
             editor.importSelection({
                 'start': 14,
                 'end': 14,
-                'editableElementIndex': 1,
                 'emptyBlocksIndex': 3
             });
 
             var innerElement = window.getSelection().getRangeAt(0).startContainer;
-            expect(Util.isDescendant(editor.elements[1].querySelectorAll('p')[1], innerElement, true)).toBe(false, 'moved selection beyond non-empty block element');
-            expect(Util.isDescendant(editor.elements[1].querySelector('h2'), innerElement, true)).toBe(true, 'moved selection to element to incorrect block element');
+            expect(Util.isDescendant(editor.elements[0].querySelectorAll('p')[1], innerElement, true)).toBe(false, 'moved selection beyond non-empty block element');
+            expect(Util.isDescendant(editor.elements[0].querySelector('h2'), innerElement, true)).toBe(true, 'moved selection to element to incorrect block element');
         });
     });
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1000,7 +1000,20 @@ function MediumEditor(elements, options) {
             }
 
             if (inSelectionState.emptyBlocksIndex && selectionState.end === nextCharIndex) {
-                var targetNode = Util.getBlockElementByIndex(range.startContainer, inSelectionState.emptyBlocksIndex);
+                var targetNode = Util.getBlockContainer(range.startContainer),
+                    index = 0;
+                // Skip over empty blocks until we hit the block we want the selection to be in
+                while (index < inSelectionState.emptyBlocksIndex && targetNode.nextSibling) {
+                    targetNode = targetNode.nextSibling;
+                    index++;
+                    // If we find a non-empty block, ignore the emptyBlocksIndex and just put selection here
+                    if (targetNode.textContent.length > 0) {
+                        break;
+                    }
+                }
+
+                // We're selecting a high-level block node, so make sure the cursor gets moved into the deepest
+                // element at the beginning of the block
                 range.setStart(Util.getFirstLeafNode(targetNode), 0);
                 range.collapse(true);
             }

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1000,9 +1000,8 @@ function MediumEditor(elements, options) {
             }
 
             if (inSelectionState.emptyBlocksIndex && selectionState.end === nextCharIndex) {
-                var targetNode = Selection.getSelectionTargetOverEmptyBlocks(range.startContainer,
-                    inSelectionState.emptyBlocksIndex, this.options.ownerDocument, editableElement);
-                range.setStart(targetNode, 0);
+                var targetNode = Util.getBlockElementByIndex(range.startContainer, inSelectionState.emptyBlocksIndex);
+                range.setStart(Util.getFirstLeafNode(targetNode), 0);
                 range.collapse(true);
             }
 

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -12,21 +12,6 @@ var Selection;
         }
     }
 
-    function adjustEmptyBlocksRelativeToCursorChildren(node, emptyBlocksCount, cursorContainer, cursorOffset) {
-        if (node.nodeType === 3) {
-            if (cursorOffset !== 0) {
-                emptyBlocksCount = 0;
-            }
-        } else {
-            for (var i = 0; i < cursorOffset; i++) {
-                if (cursorContainer.childNodes[i].textContent !== '') {
-                    emptyBlocksCount = 0;
-                }
-            }
-        }
-        return emptyBlocksCount;
-    }
-
     Selection = {
         findMatchingSelectionParent: function (testElementFunction, contentWindow) {
             var selection = contentWindow.getSelection(),
@@ -108,6 +93,19 @@ var Selection;
         // in which case it returns the count of such preceding paragraphs, including
         // the empty paragraph in which the cursor itself may be embedded.
         getIndexRelativeToAdjacentEmptyBlocks: function (doc, root, cursorContainer, cursorOffset) {
+            // If there is text in front of the cursor, that means there isn't only empty blocks before it
+            if (cursorContainer.nodeType === 3 && cursorOffset > 0) {
+                return 0;
+            }
+
+            // Check if the block that contains the cursor has any other text in front of the cursor
+            var node = cursorContainer.nodeType === 3 ? cursorContainer : cursorContainer.childNodes[cursorOffset];
+            if (!Util.isElementAtBeginningOfBlock(node)) {
+                return 0;
+            }
+
+            // Walk over block elements, counting number of empty blocks between last piece of text
+            // and the block the cursor is in
             var treeWalker = doc.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, filterOnlyParentElements, false),
                 emptyBlocksCount = 0;
             while (treeWalker.nextNode()) {
@@ -115,23 +113,7 @@ var Selection;
                 if (blockIsEmpty || emptyBlocksCount > 0) {
                     emptyBlocksCount += 1;
                 }
-                if (treeWalker.currentNode === cursorContainer) {
-                    return adjustEmptyBlocksRelativeToCursorChildren(treeWalker.currentNode, emptyBlocksCount,
-                        cursorContainer, cursorOffset);
-                } else if (Util.isDescendant(treeWalker.currentNode, cursorContainer, false)) {
-                    // Find if there is text before the cursor container and if so, reset the block count
-                    treeWalker = doc.createTreeWalker(treeWalker.currentNode,
-                        NodeFilter.SHOW_ELEMENT|NodeFilter.SHOW_TEXT, null, false);
-                    var node;
-                    while (node = treeWalker.nextNode()) {
-                        if (node === cursorContainer) {
-                            return adjustEmptyBlocksRelativeToCursorChildren(node, emptyBlocksCount, cursorContainer,
-                                cursorOffset);
-                        }
-                        if (node.nodeType === 3) {
-                            emptyBlocksCount = 0;
-                        }
-                    }
+                if (Util.isDescendant(treeWalker.currentNode, cursorContainer, true)) {
                     return emptyBlocksCount;
                 }
                 if (!blockIsEmpty) {
@@ -139,7 +121,7 @@ var Selection;
                 }
             }
 
-            return 0;
+            return emptyBlocksCount;
         },
 
         selectionInContentEditableFalse: function (contentWindow) {

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -77,9 +77,11 @@ var Selection;
             }
 
             // Check if the block that contains the cursor has any other text in front of the cursor
-            var node = cursorContainer.nodeType === 3 ? cursorContainer : cursorContainer.childNodes[cursorOffset];
-            if (!Util.isElementAtBeginningOfBlock(node)) {
-                return 0;
+            if (cursorContainer.childNodes.length !== cursorOffset) {
+                var node = cursorContainer.nodeType === 3 ? cursorContainer : cursorContainer.childNodes[cursorOffset];
+                if (!Util.isElementAtBeginningOfBlock(node)) {
+                    return 0;
+                }
             }
 
             // Walk over block elements, counting number of empty blocks between last piece of text

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -35,28 +35,6 @@ var Selection;
         },
 
         // Utility method called from importSelection only
-        getSelectionTargetOverEmptyBlocks: function (startContainer, countOfBlocks, document, root) {
-            function filterOnlyBlocksAndText(node) {
-                if (node.nodeType === 3 || Util.parentElements.indexOf(node.nodeName.toLowerCase()) !== -1) {
-                    return NodeFilter.FILTER_ACCEPT;
-                } else {
-                    return NodeFilter.FILTER_SKIP;
-                }
-            }
-            var treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT|NodeFilter.SHOW_TEXT,
-                filterOnlyBlocksAndText, false);
-
-            treeWalker.currentNode = startContainer;
-            var prevNode,
-                node;
-            while ((node = treeWalker.nextNode()) && node.nodeType !== 3 && countOfBlocks > 0) {
-                prevNode = node;
-                countOfBlocks -= 1;
-            }
-            return prevNode;
-        },
-
-        // Utility method called from importSelection only
         importSelectionMoveCursorPastAnchor: function (selectionState, range) {
             var nodeInsideAnchorTagFunction = function (node) {
                 return node.nodeName.toLowerCase() === 'a';

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -649,6 +649,23 @@ var Util;
         },
         /* END - based on http://stackoverflow.com/a/6183069 */
 
+        isElementAtBeginningOfBlock: function (node) {
+            var textVal,
+                sibling;
+            while (node.nodeType === 3 ||
+                (this.parentElements.indexOf(node.tagName.toLowerCase()) === -1 && !node.getAttribute('data-medium-element'))) { // TODO: Change this in v5.0.0
+                sibling = node;
+                while (sibling = sibling.previousSibling) {
+                    textVal = sibling.nodeType === 3 ? sibling.nodeValue : sibling.textContent;
+                    if (textVal.length > 0) {
+                        return false;
+                    }
+                }
+                node = node.parentNode;
+            }
+            return true;
+        },
+
         ensureUrlHasProtocol: function (url) {
             if (url.indexOf('://') === -1) {
                 return 'http://' + url;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -672,17 +672,6 @@ var Util;
             });
         },
 
-        getBlockElementByIndex: function (startElement, index) {
-            var block = this.getBlockContainer(startElement);
-            for (var i = 0; i < index; i++) {
-                if (!block.nextSibling) {
-                    break;
-                }
-                block = block.nextSibling;
-            }
-            return block;
-        },
-
         getFirstLeafNode: function (element) {
             while (element && element.firstChild) {
                 element = element.firstChild;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,4 +1,4 @@
-/*global NodeFilter, console, Selection*/
+/*global NodeFilter, Selection*/
 
 var Util;
 
@@ -666,6 +666,30 @@ var Util;
             return true;
         },
 
+        getBlockContainer: function (element) {
+            return this.traverseUp(element, function (el) {
+                return Util.parentElements.indexOf(el.tagName.toLowerCase()) !== -1;
+            });
+        },
+
+        getBlockElementByIndex: function (startElement, index) {
+            var block = this.getBlockContainer(startElement);
+            for (var i = 0; i < index; i++) {
+                if (!block.nextSibling) {
+                    break;
+                }
+                block = block.nextSibling;
+            }
+            return block;
+        },
+
+        getFirstLeafNode: function (element) {
+            while (element && element.firstChild) {
+                element = element.firstChild;
+            }
+            return element;
+        },
+
         ensureUrlHasProtocol: function (url) {
             if (url.indexOf('://') === -1) {
                 return 'http://' + url;
@@ -675,7 +699,7 @@ var Util;
 
         warn: function () {
             if (window.console !== undefined && typeof window.console.warn === 'function') {
-                window.console.warn.apply(console, arguments);
+                window.console.warn.apply(window.console, arguments);
             }
         },
 


### PR DESCRIPTION
After reading through the methods that you made, I thought there might be some alternate ways to do things and didn't think it be easy to tell without comparing code.

So there are 2 commits for alternate ways to county empty blocks, and restoring the selection incorporating empty blocks.

Let's sync up and discuss if these changes are worth taking or not.  Worst case, we can cherry-pick in the additional tests.
